### PR TITLE
VIV-46 [BACK] Champs migration non nullable

### DIFF
--- a/prisma/migrations/20230424170013_bddfix/migration.sql
+++ b/prisma/migrations/20230424170013_bddfix/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE `Account` MODIFY `name` VARCHAR(191) NULL,
+    MODIFY `lastName` VARCHAR(191) NULL,
+    MODIFY `phoneNumber` VARCHAR(191) NULL,
+    MODIFY `lastDiploma` VARCHAR(191) NULL,
+    MODIFY `cv` BLOB NULL;
+
+-- AlterTable
+ALTER TABLE `JobDescription` MODIFY `skills` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,16 +14,16 @@ model Account {
   id               Int             @id @default(autoincrement())
   email            String          @unique
   password         String
-  name             String
-  lastName         String
-  phoneNumber      String          @unique
-  lastDiploma      String
+  name             String?
+  lastName         String?
+  phoneNumber      String?          @unique
+  lastDiploma      String?
   hr               Boolean
-  cv               Bytes           @db.Blob()
+  cv               Bytes?           @db.Blob()
   interests        Interests[]
   profileType      ProfileType?    @relation(fields: [profileTypeId], references: [id])
   profileTypeId    Int?
-  JobDescription   JobDescription? @relation(fields: [jobDescriptionId], references: [id])
+  jobDescription   JobDescription? @relation(fields: [jobDescriptionId], references: [id])
   jobDescriptionId Int?
 }
 
@@ -31,21 +31,21 @@ model ProfileType {
   id          Int       @id @default(autoincrement())
   label       String
   description String
-  Account     Account[]
+  account     Account[]
 }
 
 model JobDescription {
   id             Int       @id @default(autoincrement())
   jobName        String
   jobDescription String
-  skills         String
-  idAccount      Account[]
+  skills         String?
+  account      Account[]
 }
 
 model Interests {
   id            Int      @id @default(autoincrement())
   labelInterest String
-  Account       Account? @relation(fields: [accountId], references: [id])
+  account       Account? @relation(fields: [accountId], references: [id])
   accountId     Int?
   Panel         Panel?   @relation(fields: [panelId], references: [id])
   panelId       Int?


### PR DESCRIPTION
Fix des champs qui n'étaient pas nullable sur la table Account